### PR TITLE
Added "default" case to MODE.ino switch statement

### DIFF
--- a/src/MODE.ino
+++ b/src/MODE.ino
@@ -71,6 +71,9 @@ void MODE() {
     case 18:
       bpm();
       break;
+    default:
+      flex_mono(); //this can be whatever default mode you want
+      break;
   }
 
   // set the blend ratio for the video cross fade


### PR DESCRIPTION
Default cases are an important error handling tool for switch statements, especially those involved in state machine processes (which is essentially what MODE.ino is). They account for unexpected values coming into the switch statement (that is, if the value coming in doesn't trigger any distinct case).